### PR TITLE
test skeleton merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,20 +7,26 @@ jobs:
     strategy:
       matrix:
         python:
-        - 3.7
-        - '3.10'
-        - '3.11'
+        - "3.7"
+        - "3.10"
+        - "3.11"
+        # Workaround for actions/setup-python#508
+        dev:
+        - -dev
         platform:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        include:
+        - python: pypy3.9
+          platform: ubuntu-latest
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}-dev
+          python-version: ${{ matrix.python }}${{ matrix.dev }}
       - name: Install tox
         run: |
           python -m pip install tox
@@ -52,7 +58,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11-dev"
+          python-version: 3.11-dev
       - name: Install tox
         run: |
           python -m pip install tox

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,3 +4,10 @@ python:
   - path: .
     extra_requirements:
       - docs
+
+# workaround for readthedocs/readthedocs.org#9623
+build:
+  # workaround for readthedocs/readthedocs.org#9635
+  os: ubuntu-22.04
+  tools:
+    python: "3"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-extensions = ['sphinx.ext.autodoc', 'jaraco.packaging.sphinx', 'rst.linker']
+extensions = [
+    'sphinx.ext.autodoc',
+    'jaraco.packaging.sphinx',
+]
 
 master_doc = "index"
 
+# Link dates and other references in the changelog
+extensions += ['rst.linker']
 link_files = {
     '../CHANGES.rst': dict(
         using=dict(GH='https://github.com'),
@@ -25,7 +30,7 @@ link_files = {
     )
 }
 
-# Be strict about any broken references:
+# Be strict about any broken references
 nitpicky = True
 
 # Include Python intersphinx mapping to prevent failures
@@ -34,3 +39,6 @@ extensions += ['sphinx.ext.intersphinx']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }
+
+# Preserve authored syntax for defaults
+autodoc_preserve_defaults = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@ extensions = [
 ]
 
 master_doc = "index"
+html_theme = "furo"
 
 # Link dates and other references in the changelog
 extensions += ['rst.linker']

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ testing =
 
 docs =
 	# upstream
-	sphinx
+	sphinx >= 3.5
 	jaraco.packaging >= 9
 	rst.linker >= 1.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ docs =
 	sphinx >= 3.5
 	jaraco.packaging >= 9
 	rst.linker >= 1.9
+	furo
 
 	# local
 


### PR DESCRIPTION
- Add PyPy to the test matrix on Linux. Fixes jaraco/skeleton#63.
- When rendering docs, preserve the syntax for defaults. Fixes jaraco/path#197.
- Adopt furo theme for docs.
- Indicate to use latest Python version (workaround for readthedocs/readthedocs.org/#9623). Requires also specifying the OS version (workaround for readthedocs/readthedocs.org#9635).
